### PR TITLE
Chore/automatically test against multiple rubies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,8 @@
 require: rubocop-rspec
 
 AllCops:
+  Exclude:
+    - rubygems*/
   TargetRubyVersion: 2.3
 
 Documentation:

--- a/bin/circle_ci/setup
+++ b/bin/circle_ci/setup
@@ -8,6 +8,8 @@ wget https://rubygems.org/rubygems/rubygems-2.6.10.tgz
 tar xzvf rubygems-2.6.10.tgz
 cd rubygems-2.6.10
 ruby setup.rb
+cd ..
+rm -rf rubygems-2.6.10
 bundle install
 
 # Do any other automated setup that you need to do here

--- a/bin/circle_ci/setup
+++ b/bin/circle_ci/setup
@@ -4,8 +4,10 @@ IFS=$'\n\t'
 set -vx
 
 gem install bundler
-gem install rubygems-update
-update_rubygems
+wget https://rubygems.org/rubygems/rubygems-2.6.10.tgz
+tar xzvf rubygems-2.6.10.tgz
+cd rubygems-2.6.10
+ruby setup.rb
 bundle install
 
 # Do any other automated setup that you need to do here

--- a/bin/circle_ci/test
+++ b/bin/circle_ci/test
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-bundle exec rubocop
 bundle exec rspec -r rspec_junit_formatter --format progress \
             --format RspecJunitFormatter \
             -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+bundle exec rubocop

--- a/bin/circle_ci/test
+++ b/bin/circle_ci/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle exec rubocop
+bundle exec rspec -r rspec_junit_formatter --format progress \
+            --format RspecJunitFormatter \
+            -o $CIRCLE_TEST_REPORTS/rspec/junit.xml

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+gem install bundler
 bundle install
 
 # Do any other automated setup that you need to do here

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
+sudo gem update --system
 gem install bundler
 bundle install
 

--- a/bin/test
+++ b/bin/test
@@ -3,5 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-bundle exec rubocop
 bundle exec rake spec
+bundle exec rubocop

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - rvm 2.1.0,2.2.0 --verbose do ./bin/setup
+    - rvm 2.1.10,2.2.6,2.3.3,2.4.0 --verbose do ./bin/setup
 test:
   override:
-    - rvm 2.1.0,2.2.0 --verbose do ./bin/circle_ci/test
+    - rvm 2.1.10,2.2.6,2.3.3,2.4.0 --verbose do ./bin/circle_ci/test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - rvm 2.1.10,2.2.6,2.3.3,2.4.0 --verbose do ./bin/setup
+    - rvm 2.1.10,2.2.6,2.3.3,2.4.0 --verbose do ./bin/circle_ci/setup
 test:
   override:
     - rvm 2.1.10,2.2.6,2.3.3,2.4.0 --verbose do ./bin/circle_ci/test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - rvm-exec 2.1.0, 2.2.0 ./bin/setup
+    - rvm 2.1.0,2.2.0 --verbose do ./bin/setup
 test:
   override:
-    - rvm-exec 2.1.0, 2.2.0 ./bin/test
+    - rvm 2.1.0,2.2.0 --verbose do ./bin/test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - rvm-exec 2.1.0 ./bin/setup
+    - rvm-exec 2.1.0, 2.2.0 ./bin/setup
 test:
   override:
-    - rvm-exec 2.1.0 ./bin/test
+    - rvm-exec 2.1.0, 2.2.0 ./bin/test

--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,4 @@ dependencies:
     - rvm 2.1.0,2.2.0 --verbose do ./bin/setup
 test:
   override:
-    - rvm 2.1.0,2.2.0 --verbose do ./bin/test
+    - rvm 2.1.0,2.2.0 --verbose do ./bin/circle_ci/test

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - ./bin/setup
+    - rvm-exec 2.1.0 ./bin/setup
 test:
   override:
-    - ./bin/test
+    - rvm-exec 2.1.0 ./bin/test

--- a/united_states.gemspec
+++ b/united_states.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-coolline'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
- Ensured `Bundler` is installed before running `bundle install`.
- Added `CircleCI`-specific `setup` (`./bin/circle_ci/setup`) and `test` (`./bin/circle_ci/test`) `bash` scripts.
- Updated `circle.yml` to run against `ruby` versions `2.1.10`, `2.2.6`, `2.3.3`, and `2.4.0`.