### PR TITLE
Add supported ruby versions to README.md

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require: rubocop-rspec
 AllCops:
   Exclude:
     - rubygems*/
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.1
 
 Documentation:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Or install it yourself as:
 
     $ gem install united_states
 
+`united_states` is tested against the following [stable `ruby` versions](https://www.ruby-lang.org/en/downloads/):
+  * MRI 2.1.10
+  * MRI 2.2.6
+  * MRI 2.3.3
+  * MRI 2.4.0
+
 ## Usage
 
 ```ruby

--- a/lib/united_states.rb
+++ b/lib/united_states.rb
@@ -9,7 +9,7 @@ module UnitedStates
   # Thrown when someone attempts to search for a state with
   # the wrong name or postal code.
   class NoDesignationFoundError < StandardError
-    DEFAULT_MESSAGE = 'No State was found.'
+    DEFAULT_MESSAGE = 'No State was found.'.freeze
 
     def initialize(message = DEFAULT_MESSAGE)
       super(message)

--- a/lib/united_states/state/postal_code.rb
+++ b/lib/united_states/state/postal_code.rb
@@ -7,7 +7,8 @@ module UnitedStates
       # Thrown when someone attempts to make a PostalCode instance
       # from a string longer than 2 characters.
       class StringTooLongError < StandardError
-        DEFAULT_MESSAGE = 'string too long, postal code must be 2 characters'
+        DEFAULT_MESSAGE = 'string too long, postal code must be '\
+                          '2 characters'.freeze
 
         def initialize(message = DEFAULT_MESSAGE)
           super(message)
@@ -17,7 +18,8 @@ module UnitedStates
       # Thrown when someone attempts to make a PostalCode instance
       # from a string shorter than 2 characters.
       class StringTooShortError < StandardError
-        DEFAULT_MESSAGE = 'string too short, postal codes must be 2 characters'
+        DEFAULT_MESSAGE = 'string too short, postal codes must be '\
+                          '2 characters'.freeze
 
         def initialize(message = DEFAULT_MESSAGE)
           super(message)

--- a/lib/united_states/version.rb
+++ b/lib/united_states/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module UnitedStates
-  VERSION = '1.1.0'
+  VERSION = '1.1.0'.freeze
 end


### PR DESCRIPTION
- Add the supported ruby versions to `README.md`
- Set `.rubocop.yml` `TargetRubyVersion` to lowest targeted version per 
  (https://raw.githubusercontent.com/bbatsov/rubocop/master/config/default.yml)

closes #4