### PR TITLE
Deploy Version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ __Change Groups__:
 `Added`, `Changed`, `Deprecated`, `Fixed`, `Removed`, `Security`
 
 ## [Unreleased]
+
+## [1.1.1] - 2017-02-18
 ### Added
 - `CircleCI` now tests against `Ruby` versions `2.1.10`, `2.2.6`, `2.3.3`, `2.4.0`.
 - [`CHANGELOG.md`](CHANGELOG.md) following http://keepachangelog.com/en/0.3.0/.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ __Change Groups__:
 
 ### Changed
 - `./bin/` scripts are verbose.
-- [`README.md`](README.md) `Development` section expanded with branching details.
+- `README.md` `Development` section expanded with branching details.
+- `README.md` `Deployment` section expanded with branching details.
 
 ## [1.1.0] - 2017-02-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+__Change Groups__:
+
+`Added`, `Changed`, `Deprecated`, `Fixed`, `Removed`, `Security`
+
+## [Unreleased]
+### Added
+- `CircleCI` now tests against `Ruby` versions `2.1.10`, `2.2.6`, `2.3.3`, `2.4.0`.
+- [`CHANGELOG.md`](CHANGELOG.md) following http://keepachangelog.com/en/0.3.0/.
+- `./bin/circle_ci` for all `CircleCI`-specific scripts.
+
+### Changed
+- `./bin/` scripts are verbose.
+- [`README.md`](README.md) `Development` section expanded with branching details.
+
+## [1.1.0] - 2017-02-11
+### Added
+- `UnitedStates.find_by_name(name)` to find a `UnitedStates::State::Designation` with matching name.
+- `UnitedStates.find_by_postal_code(postal_code)` to find a `UnitedStates::State::Designation` with matching postal code.
+- `UnitedStates.[](name_or_postal_code)` to find a `UnitedStates::State::Designation` with matching name or postal code.
+- Support for `Symbol` values as "name" or "postal code" parameters.
+
+### Changed
+- All references of `abbreviation` to `postal code`.
+- `UnitedStates.abbreviations` -> `.postal_codes`
+- `UnitedStates::State::Abbreviation` -> `UnitedStates::State::PostalCode`.
+- `UnitedStates::State::Designation#abbreviation` -> `#postal_code`
+
+
+## [1.0.2] - 2017-02-09
+### Added
+- Usage examples to `README.md`.
+
+## [1.0.1] - 2017-02-08
+### Fixed
+- GitHub repo url in `README.md`.
+
+## [1.0.0] - 2017-02-08
+### Added
+- `UnitedStates` module.
+- `UnitedStates::State::Abbreviation` class.
+- `UnitedStates::State::Designation` class.
+- `UnitedStates::State::Name` class.
+- `./bin/document` to generate documentation.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,18 @@ install`.
 
 ### Deployment
 To release a new version, you must first have authorization to push
-to `rubygems`. If so, update the version number in
+to `rubygems`. If so, make a new
+`chore/#ISSUE_NUMBER_update_version_to_MAJOR_MINOR_PATCH`, update
+`UnitedStates::VERSION` number (per
+[Semantic Versioning](http://semver.org/)) in
 [`lib/united_states/version.rb`](lib/united_states/version.rb),
-and then run `bundle exec rake release`, which will create a
+and then make a pull request merging to `development`.
+
+After `development` has been updated with the new version number,
+make a pull request merging the new changes to `master`.
+
+Once `master` has been updated, checkout the latest `master`
+and run `bundle exec rake release`, which will create a
 git tag for the version, push git commits and tags, and push the
 `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -47,19 +47,41 @@ UnitedStates['car']
 
 ## Development
 
-After checking out the repo, run `./bin/setup` to install dependencies.
-Then, run `./bin/test` to run code quality checks and tests.
-Then, run './bin/document' to generate `doc/` and open `doc/index.html`
+### Branching
+
+Checkout the repo. If making a `hot_fix` branch, branch from
+`master`. If making a `bug_fix`/`chore`/`enhancement` branch,
+branch from
+[`development`](https://github.com/kWhittington/united_states/tree/develop).
+Be sure to update [`CHANGELOG.md`](CHANGELOG.md)
+(see http://keepachangelog.com/en/0.3.0/) with your changes.
+
+### Setup
+Run `./bin/setup` to install dependencies.
+
+### Testing
+Run `./bin/test` to run code quality checks and tests.
+
+### Documenting
+Run `./bin/document` to generate `doc/` and open
+[`doc/index.html`](doc/index.html)
 to view the documentation. See
 http://www.rubydoc.info/gems/yard/file/docs/GettingStarted.md for
 documentation syntax.
 
-You can also run `./bin/console` for an interactive prompt that will allow
+### Seat-of-the-Pants Testing
+Run `./bin/console` for an interactive prompt that will allow
 you to experiment.
 
+### Manual installation
 To install this gem onto your local machine, run `bundle exec rake
-install`. To release a new version, update the version number in
-`version.rb`, and then run `bundle exec rake release`, which will create a
+install`.
+
+### Deployment
+To release a new version, you must first have authorization to push
+to `rubygems`. If so, update the version number in
+[`lib/united_states/version.rb`](lib/united_states/version.rb),
+and then run `bundle exec rake release`, which will create a
 git tag for the version, push git commits and tags, and push the
 `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ to `rubygems`. If so, make a new
 `UnitedStates::VERSION` number (per
 [Semantic Versioning](http://semver.org/)) in
 [`lib/united_states/version.rb`](lib/united_states/version.rb),
-and then make a pull request merging to `development`.
+change the `Unreleased` section of `CHANGELOG.md` to the new version
+number, and then make a pull request merging to `development`.
 
 After `development` has been updated with the new version number,
 make a pull request merging the new changes to `master`.

--- a/lib/united_states/version.rb
+++ b/lib/united_states/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module UnitedStates
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.1.1'.freeze
 end


### PR DESCRIPTION
## [1.1.1] - 2017-02-18
### Added
- `CircleCI` now tests against `Ruby` versions `2.1.10`, `2.2.6`, `2.3.3`, `2.4.0`.
- [`CHANGELOG.md`](CHANGELOG.md) following http://keepachangelog.com/en/0.3.0/.
- `./bin/circle_ci` for all `CircleCI`-specific scripts.

### Changed
- `./bin/` scripts are verbose.
- `README.md` `Development` section expanded with branching details.
- `README.md` `Deployment` section expanded with branching details.