### PR TITLE
Fix minor documentation errors

### DIFF
--- a/lib/united_states/state/designation.rb
+++ b/lib/united_states/state/designation.rb
@@ -6,14 +6,12 @@ module UnitedStates
   module State
     # Represents the various way to designate a state (e.g. name, postal code).
     class Designation
-      # @!attribute [r] postal_code
-      #   @return [UnitedStates::State::PostalCode]
-      #    the state's postal code
+      # @return [UnitedStates::State::PostalCode]
+      #  the state's postal code
       attr_reader :postal_code
 
-      # @!attribute [r] name
-      #   @return [UnitedStates::State::Name]
-      #    the state's name
+      # @return [UnitedStates::State::Name]
+      #  the state's name
       attr_reader :name
 
       # @param name [String]

--- a/lib/united_states/state/name.rb
+++ b/lib/united_states/state/name.rb
@@ -11,7 +11,7 @@ module UnitedStates
         @string = string.to_s
       end
 
-      # @param [UnitedStates::State::Name]
+      # @param other [UnitedStates::State::Name]
       # @return [Boolean]
       #  whether or not other.to_s matches self.to_s
       def ==(other)

--- a/lib/united_states/state/postal_code.rb
+++ b/lib/united_states/state/postal_code.rb
@@ -40,7 +40,7 @@ module UnitedStates
         @string = string
       end
 
-      # @param [UnitedStates::State::PostalCode]
+      # @param other [UnitedStates::State::PostalCode]
       # @return [Boolean]
       #  whether or not other.to_s matches self.to_s
       def ==(other)


### PR DESCRIPTION
There were a few `yard` documentation errors in some of the
files. This patch corrects them so they display properly
after `./bin/document` generates the HTML.