### PR TITLE
Add UnitedStates.array_from_hashes(*hashes)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require: rubocop-rspec
 AllCops:
   Exclude:
     - rubygems*/
+    - united_states.gemspec
   TargetRubyVersion: 2.1
 
 Documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ __Change Groups__:
 `Added`, `Changed`, `Deprecated`, `Fixed`, `Removed`, `Security`
 
 ## [Unreleased]
+### Added
+- `UnitedStates.array_from_hashes(*hashes)`
+- `UnitedStates::State::Designation.from_hash(**hash)`
+- Example of `UnitedStates::State::Designation#initialize(...)`
+
+### Changed
+- `UnitedStates.all` to use `UnitedStates.array_from_hashes(*hashes)`
+
+### Fixed
+- `Designation`, `Name`, and `PostalCode` yard documentation typos.
+- `"Abbrevation"` typos, now `"PostalCode"`.
 
 ## [1.1.1] - 2017-02-18
 ### Added

--- a/lib/united_states.rb
+++ b/lib/united_states.rb
@@ -2,8 +2,6 @@
 require 'united_states/version'
 require 'united_states/state/designation'
 
-# rubocop: disable Metrics/ModuleLength
-#
 # Top-level namespace for this gem.
 module UnitedStates
   # Thrown when someone attempts to search for a state with
@@ -32,116 +30,66 @@ module UnitedStates
     find_by_postal_code(name_or_postal_code)
   end
 
-  # rubocop: disable Metrics/AbcSize
   # rubocop: disable Metrics/MethodLength
+  # rubocop: disable Style/BracesAroundHashParameters
+
   # @return [Array<UnitedStates::State::Designation>]
   #  a collection of all U.S. State Designations.
   def self.all
-    [
-      UnitedStates::State::Designation.new(
-        name: 'Alabama', postal_code: 'AL'),
-      UnitedStates::State::Designation.new(
-        name: 'Alaska', postal_code: 'AK'),
-      UnitedStates::State::Designation.new(
-        name: 'Arizona', postal_code: 'AZ'),
-      UnitedStates::State::Designation.new(
-        name: 'Arkansas', postal_code: 'AR'),
-      UnitedStates::State::Designation.new(
-        name: 'California', postal_code: 'CA'),
-      UnitedStates::State::Designation.new(
-        name: 'Colorado', postal_code: 'CO'),
-      UnitedStates::State::Designation.new(
-        name: 'Connecticut', postal_code: 'CT'),
-      UnitedStates::State::Designation.new(
-        name: 'Delaware', postal_code: 'DE'),
-      UnitedStates::State::Designation.new(
-        name: 'Florida', postal_code: 'FL'),
-      UnitedStates::State::Designation.new(
-        name: 'Georgia', postal_code: 'GA'),
-      UnitedStates::State::Designation.new(
-        name: 'Hawaii', postal_code: 'HI'),
-      UnitedStates::State::Designation.new(
-        name: 'Idaho', postal_code: 'ID'),
-      UnitedStates::State::Designation.new(
-        name: 'Illinois', postal_code: 'IL'),
-      UnitedStates::State::Designation.new(
-        name: 'Indiana', postal_code: 'IN'),
-      UnitedStates::State::Designation.new(
-        name: 'Iowa', postal_code: 'IA'),
-      UnitedStates::State::Designation.new(
-        name: 'Kansas', postal_code: 'KS'),
-      UnitedStates::State::Designation.new(
-        name: 'Kentucky', postal_code: 'KY'),
-      UnitedStates::State::Designation.new(
-        name: 'Louisiana', postal_code: 'LA'),
-      UnitedStates::State::Designation.new(
-        name: 'Maine', postal_code: 'ME'),
-      UnitedStates::State::Designation.new(
-        name: 'Maryland', postal_code: 'MD'),
-      UnitedStates::State::Designation.new(
-        name: 'Massachusetts', postal_code: 'MA'),
-      UnitedStates::State::Designation.new(
-        name: 'Michigan', postal_code: 'MI'),
-      UnitedStates::State::Designation.new(
-        name: 'Minnesota', postal_code: 'MN'),
-      UnitedStates::State::Designation.new(
-        name: 'Mississippi', postal_code: 'MS'),
-      UnitedStates::State::Designation.new(
-        name: 'Missouri', postal_code: 'MO'),
-      UnitedStates::State::Designation.new(
-        name: 'Montana', postal_code: 'MT'),
-      UnitedStates::State::Designation.new(
-        name: 'Nebraska', postal_code: 'NE'),
-      UnitedStates::State::Designation.new(
-        name: 'Nevada', postal_code: 'NV'),
-      UnitedStates::State::Designation.new(
-        name: 'New Hampshire', postal_code: 'NH'),
-      UnitedStates::State::Designation.new(
-        name: 'New Jersey', postal_code: 'NJ'),
-      UnitedStates::State::Designation.new(
-        name: 'New Mexico', postal_code: 'NM'),
-      UnitedStates::State::Designation.new(
-        name: 'New York', postal_code: 'NY'),
-      UnitedStates::State::Designation.new(
-        name: 'North Carolina', postal_code: 'NC'),
-      UnitedStates::State::Designation.new(
-        name: 'North Dakota', postal_code: 'ND'),
-      UnitedStates::State::Designation.new(
-        name: 'Ohio', postal_code: 'OH'),
-      UnitedStates::State::Designation.new(
-        name: 'Oklahoma', postal_code: 'OK'),
-      UnitedStates::State::Designation.new(
-        name: 'Oregon', postal_code: 'OR'),
-      UnitedStates::State::Designation.new(
-        name: 'Pennsylvania', postal_code: 'PA'),
-      UnitedStates::State::Designation.new(
-        name: 'Rhode Island', postal_code: 'RI'),
-      UnitedStates::State::Designation.new(
-        name: 'South Carolina', postal_code: 'SC'),
-      UnitedStates::State::Designation.new(
-        name: 'South Dakota', postal_code: 'SD'),
-      UnitedStates::State::Designation.new(
-        name: 'Tennessee', postal_code: 'TN'),
-      UnitedStates::State::Designation.new(
-        name: 'Texas', postal_code: 'TX'),
-      UnitedStates::State::Designation.new(
-        name: 'Utah', postal_code: 'UT'),
-      UnitedStates::State::Designation.new(
-        name: 'Vermont', postal_code: 'VT'),
-      UnitedStates::State::Designation.new(
-        name: 'Virginia', postal_code: 'VA'),
-      UnitedStates::State::Designation.new(
-        name: 'Washington', postal_code: 'WA'),
-      UnitedStates::State::Designation.new(
-        name: 'West Virginia', postal_code: 'WV'),
-      UnitedStates::State::Designation.new(
-        name: 'Wisconsin', postal_code: 'WI'),
-      UnitedStates::State::Designation.new(
-        name: 'Wyoming', postal_code: 'WY')
-    ]
+    array_from_hashes(
+      { name: 'Alabama', postal_code: 'AL' },
+      { name: 'Alaska', postal_code: 'AK' },
+      { name: 'Arizona', postal_code: 'AZ' },
+      { name: 'Arkansas', postal_code: 'AR' },
+      { name: 'California', postal_code: 'CA' },
+      { name: 'Colorado', postal_code: 'CO' },
+      { name: 'Connecticut', postal_code: 'CT' },
+      { name: 'Delaware', postal_code: 'DE' },
+      { name: 'Florida', postal_code: 'FL' },
+      { name: 'Georgia', postal_code: 'GA' },
+      { name: 'Hawaii', postal_code: 'HI' },
+      { name: 'Idaho', postal_code: 'ID' },
+      { name: 'Illinois', postal_code: 'IL' },
+      { name: 'Indiana', postal_code: 'IN' },
+      { name: 'Iowa', postal_code: 'IA' },
+      { name: 'Kansas', postal_code: 'KS' },
+      { name: 'Kentucky', postal_code: 'KY' },
+      { name: 'Louisiana', postal_code: 'LA' },
+      { name: 'Maine', postal_code: 'ME' },
+      { name: 'Maryland', postal_code: 'MD' },
+      { name: 'Massachusetts', postal_code: 'MA' },
+      { name: 'Michigan', postal_code: 'MI' },
+      { name: 'Minnesota', postal_code: 'MN' },
+      { name: 'Mississippi', postal_code: 'MS' },
+      { name: 'Missouri', postal_code: 'MO' },
+      { name: 'Montana', postal_code: 'MT' },
+      { name: 'Nebraska', postal_code: 'NE' },
+      { name: 'Nevada', postal_code: 'NV' },
+      { name: 'New Hampshire', postal_code: 'NH' },
+      { name: 'New Jersey', postal_code: 'NJ' },
+      { name: 'New Mexico', postal_code: 'NM' },
+      { name: 'New York', postal_code: 'NY' },
+      { name: 'North Carolina', postal_code: 'NC' },
+      { name: 'North Dakota', postal_code: 'ND' },
+      { name: 'Ohio', postal_code: 'OH' },
+      { name: 'Oklahoma', postal_code: 'OK' },
+      { name: 'Oregon', postal_code: 'OR' },
+      { name: 'Pennsylvania', postal_code: 'PA' },
+      { name: 'Rhode Island', postal_code: 'RI' },
+      { name: 'South Carolina', postal_code: 'SC' },
+      { name: 'South Dakota', postal_code: 'SD' },
+      { name: 'Tennessee', postal_code: 'TN' },
+      { name: 'Texas', postal_code: 'TX' },
+      { name: 'Utah', postal_code: 'UT' },
+      { name: 'Vermont', postal_code: 'VT' },
+      { name: 'Virginia', postal_code: 'VA' },
+      { name: 'Washington', postal_code: 'WA' },
+      { name: 'West Virginia', postal_code: 'WV' },
+      { name: 'Wisconsin', postal_code: 'WI' },
+      { name: 'Wyoming', postal_code: 'WY' })
   end
-  # rubocop: enable Metrics/AbcSize
   # rubocop: enable Metrics/MethodLength
+  # rubocop: enable Style/BracesAroundHashParameters
 
   # @example
   #  UnitedStates.find_by_name('louisiana') # => UnitedSt...Designation
@@ -170,6 +118,20 @@ module UnitedStates
     all.find { |designation| designation.postal_code == postal_code } || raise(
       NoDesignationFoundError,
       "No State with postal code, \"#{postal_code},\" was found.")
+  end
+
+  # @example
+  #  UnitedStates.array_from_hashes(
+  #    { name: 'Florida', postal_code: 'FL' },
+  #    { name: 'Iowa', postal_code: 'IA'})
+  # @param hashes [Array<Hash>]
+  #  a collection of attributes as hashes
+  # @return [Array<UnitedStates::State::Designation>]
+  #  a collection of state designations made from the given hash attributes
+  def self.array_from_hashes(*hashes)
+    hashes.map do |hash|
+      UnitedStates::State::Designation.from_hash(hash)
+    end
   end
 
   # @return [Array<UnitedStates::State::Name>]

--- a/lib/united_states/state/designation.rb
+++ b/lib/united_states/state/designation.rb
@@ -14,6 +14,26 @@ module UnitedStates
       #  the state's name
       attr_reader :name
 
+      # @example From Named Parameters
+      #  UnitedStates::State::Designation.from_hash(
+      #    name: 'Hawaii', postal_code: 'HI')
+      #  # => #<UnitedStates::State::Designation:0x...@string="HI">>
+      # @example From Variable
+      #  hawaii_hash = { name: 'Hawaii', postal_code: 'HI' }
+      #  UnitedStates::State::Designation.from_hash(hawaii_hash)
+      #  # => #<UnitedStates::State::Designation:0x...@string="HI">>
+      # @param hash [Hash]
+      #  a hash of Designation attributes, see {#initialize} for parameters
+      # @return [UnitedStates::State::Designation]
+      #  a Designation with attributes provided via hash
+      def self.from_hash(**hash)
+        new(name: hash[:name], postal_code: hash[:postal_code])
+      end
+
+      # @example
+      #  UnitedStates::State::Designation.new(
+      #    name: 'wyoming', postal_code: 'wy')
+      #  # => #<UnitedStates::State::Designation:0x007...@string="wy">>
       # @param name [String]
       # @param postal_code [String]
       # @raise [UnitedStates::State::PostalCode::StringTooLongError]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,68 @@
 # frozen_string_literal: true
 require 'bundler/setup'
+require 'pry'
 
 RSpec.configure do |config|
+  # These two settings work together to allow you to limit a spec run
+  # to individual examples or groups you care about by tagging them with
+  # `:focus` metadata. When nothing is tagged with `:focus`, all examples
+  # get run.
+  config.filter_run :focus
+  config.run_all_when_everything_filtered = true
+
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.syntax = :expect
   end
+
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    mocks.verify_partial_doubles = true
+  end
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
+  # Print the 10 slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 10
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end

--- a/spec/united_states/state/designation_spec.rb
+++ b/spec/united_states/state/designation_spec.rb
@@ -1,10 +1,34 @@
 # frozen_string_literal: true
 require 'spec_helper'
+require 'faker'
 require 'united_states/state/designation'
 
 RSpec.describe UnitedStates::State::Designation do
   subject :designation do
     described_class.new(name: name, postal_code: postal_code)
+  end
+
+  describe '.from_hash(hash)' do
+    context 'when { } are omitted' do
+      subject :from_hash do
+        described_class.from_hash(name: 'georgia', postal_code: 'ga')
+      end
+
+      it 'is a UnitedStates::State::Designation from the hash' do
+        is_expected.to eq(
+          described_class.new(name: 'Georgia', postal_code: 'GA'))
+      end
+    end
+
+    context 'when hash is a variable' do
+      subject(:from_hash) { described_class.from_hash(hash) }
+      let(:hash) { { name: 'GEORGIA', postal_code: 'GA' } }
+
+      it 'is a UnitedStates::State::Designation from the hash' do
+        is_expected.to eq(
+          described_class.new(name: 'Georgia', postal_code: 'GA'))
+      end
+    end
   end
 
   describe '.new(name:, postal_code:)' do

--- a/spec/united_states_spec.rb
+++ b/spec/united_states_spec.rb
@@ -287,6 +287,47 @@ RSpec.describe UnitedStates do
   end
   # rubocop: enable RSpec/ExampleLength
 
+  describe '.array_from_hashes(hashes)' do
+    context 'when hashes is empty' do
+      subject(:array_from_hashes) { described_class.array_from_hashes }
+
+      it('is an Array') { is_expected.to be_an(Array) }
+      it('is empty') { is_expected.to be_empty }
+    end
+
+    context 'when hashes has one hash in it' do
+      subject(:array_from_hashes) { described_class.array_from_hashes(hash) }
+      let(:hash) { { name: 'louisiana', postal_code: 'la' } }
+
+      it('is an Array') { is_expected.to be_an(Array) }
+
+      it 'includes a UnitedStates::State::Designation from the hash' do
+        is_expected.to include(
+          UnitedStates::State::Designation.new(
+            name: 'LOUISIANA', postal_code: 'LA'))
+      end
+    end
+
+    context 'when hashes has multiple hashes in it' do
+      subject :array_from_hashes do
+        described_class.array_from_hashes(florida_hash, mississippi_hash)
+      end
+
+      let(:florida_hash) { { name: 'FlorIDA', postal_code: 'fL' } }
+      let(:mississippi_hash) { { name: 'Mississippi', postal_code: 'Ms' } }
+
+      it('is an Array') { is_expected.to be_an(Array) }
+
+      it 'includes a UnitedStates::State::Designation for each' do
+        is_expected.to contain_exactly(
+          UnitedStates::State::Designation.new(
+            name: 'florida', postal_code: 'fl'),
+          UnitedStates::State::Designation.new(
+            name: 'mississippi', postal_code: 'ms'))
+      end
+    end
+  end
+
   describe '.find_by_name(name)' do
     subject(:find_by_name) { described_class.find_by_name(name) }
 

--- a/united_states.gemspec
+++ b/united_states.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'faker'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'pry-coolline'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
`UnitedStates.array_from_hashes(*hashes)` can now be used to build
a collection of `UnitedStates::State::Designation` values made
from the given hashes.

closes #16