### PR TITLE
Bump UnitedStates::VERSION to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ __Change Groups__:
 `Added`, `Changed`, `Deprecated`, `Fixed`, `Removed`, `Security`
 
 ## [Unreleased]
+
+## [1.2.0] - 2017-02-26
 ### Added
 - `UnitedStates.config_path`
 - `UnitedStates.array_from_yaml_file(path:)`

--- a/lib/united_states/version.rb
+++ b/lib/united_states/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module UnitedStates
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.2.0'.freeze
 end


### PR DESCRIPTION
Mark `UnitedStates` as official version `1.2.0`.

closes #20