### PR TITLE
Add required_ruby_version >= 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ __Change Groups__:
 `Added`, `Changed`, `Deprecated`, `Fixed`, `Removed`, `Security`
 
 ## [Unreleased]
+### Added
+- `required_ruby_version` set to `>= 2.1.0` in `.gemspec`
+
 ### Changed
 - `README.md` `Deployment` instructions updated with squash-merge walkthrough.
 

--- a/united_states.gemspec
+++ b/united_states.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
                      'in various formats.'
   spec.homepage = 'https://github.com/kWhittington/united_states'
   spec.license = 'MIT'
+  spec.required_ruby_version = '>= 2.1.0'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
The RubyGems `.gemspec` is not set to target a `ruby` version
of `2.1.0` or greater.