### PR TITLE
Make CircleCI test output Rubocop to HTML

### DIFF
--- a/bin/circle_ci/test
+++ b/bin/circle_ci/test
@@ -6,4 +6,4 @@ set -vx
 bundle exec rspec -r rspec_junit_formatter --format progress \
             --format RspecJunitFormatter \
             -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
-bundle exec rubocop
+bundle exec rubocop --format html -o $CIRCLE_TEST_REPORTS/rubocop/results.html


### PR DESCRIPTION
Hopefully we'll be able to see the Rubocop HTML file nicely
in the browser.