### PR TITLE
Hot fix/v1.2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,12 @@ Documentation:
   Exclude:
     - spec/**/*_spec.rb
 
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: same_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 Metrics/BlockLength:
   Exclude:
     - .rubocop.yml
@@ -25,9 +31,3 @@ Metrics/ClassLength:
 RSpec/DescribeClass:
   Exclude:
     - spec/support/**/*
-
-Style/MultilineMethodCallBraceLayout:
-  EnforcedStyle: same_line
-
-Style/MultilineMethodCallIndentation:
-  EnforcedStyle: indented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ __Change Groups__:
 ## [Unreleased]
 
 ## [1.2.1] - 2017-07-04
+### Changed
+- Added empty lines after magic comments (per `rubocop`).
+- Added empty lines after inline `RSpec` `subject` (per `rubocop`).
+- Namespace of `MultilineMethodCallBraceLayout` and
+  `MultilineMethodCallIndentation` (per `rubocop`).
+- Disabled `Style/IndentHeredoc` in `spec/united_states_spec.rb`.
+
 ### Fixed
 - `UnitedStates.names` would throw `NameError: uninitialized constant
    UnitedStates::Pathname` due to missing `require` statements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ __Change Groups__:
 
 ## [Unreleased]
 
+## [1.2.1] - 2017-07-04
+### Fixed
+- `UnitedStates.names` would throw `NameError: uninitialized constant
+   UnitedStates::Pathname` due to missing `require` statements.
+
 ## [1.2.0] - 2017-02-26
 ### Added
 - `UnitedStates.config_path`

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in united_states.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/lib/united_states.rb
+++ b/lib/united_states.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pathname'
 require 'united_states/version'
 require 'united_states/state/designation'

--- a/lib/united_states.rb
+++ b/lib/united_states.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pathname'
 require 'united_states/version'
 require 'united_states/state/designation'
 

--- a/lib/united_states/state/designation.rb
+++ b/lib/united_states/state/designation.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'united_states/state/postal_code'
 require 'united_states/state/name'
 

--- a/lib/united_states/version.rb
+++ b/lib/united_states/version.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module UnitedStates
   VERSION = '1.2.1'.freeze
 end

--- a/lib/united_states/version.rb
+++ b/lib/united_states/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module UnitedStates
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'bundler/setup'
+require 'pathname'
 require 'pry'
 
 # Ensure ./tmp/ exists.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'bundler/setup'
 require 'pathname'
 require 'pry'

--- a/spec/united_states/state/designation_spec.rb
+++ b/spec/united_states/state/designation_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'faker'
 require 'united_states/state/designation'
@@ -22,6 +23,7 @@ RSpec.describe UnitedStates::State::Designation do
 
     context 'when hash is a variable' do
       subject(:from_hash) { described_class.from_hash(hash) }
+
       let(:hash) { { name: 'GEORGIA', postal_code: 'GA' } }
 
       it 'is a UnitedStates::State::Designation from the hash' do

--- a/spec/united_states/state/name_spec.rb
+++ b/spec/united_states/state/name_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'faker'
 require 'united_states/state/name'
 
 RSpec.describe UnitedStates::State::Name do
   subject(:name) { described_class.new(string) }
+
   let(:string) { Faker::Lorem.word }
 
   describe '#==(other)' do

--- a/spec/united_states/state/postal_code_spec.rb
+++ b/spec/united_states/state/postal_code_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
+
 require 'spec_helper'
 require 'united_states/state/postal_code'
 
 RSpec.describe UnitedStates::State::PostalCode do
   subject(:postal_code) { described_class.new(string) }
+
   let(:string) { Faker::Lorem.characters(2) }
 
   describe '.new(string)' do

--- a/spec/united_states_spec.rb
+++ b/spec/united_states_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'pathname'
 require 'spec_helper'
 require 'united_states'
@@ -298,6 +299,7 @@ RSpec.describe UnitedStates do
 
     context 'when hashes has one hash in it' do
       subject(:array_from_hashes) { described_class.array_from_hashes(hash) }
+
       let(:hash) { { name: 'louisiana', postal_code: 'la' } }
 
       it('is an Array') { is_expected.to be_an(Array) }
@@ -329,6 +331,7 @@ RSpec.describe UnitedStates do
     end
   end
 
+  # rubocop: disable Style/IndentHeredoc
   describe '.array_from_yaml(yaml)' do
     subject(:array_from_yaml) { described_class.array_from_yaml(yaml) }
 
@@ -538,6 +541,7 @@ Wisconsin:
       end
     end
   end
+  # rubocop: enable Style/IndentHeredoc
 
   describe '.config_path' do
     subject(:config_path) { described_class.config_path }

--- a/spec/united_states_spec.rb
+++ b/spec/united_states_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pathname'
 require 'spec_helper'
 require 'united_states'
 


### PR DESCRIPTION
## [1.2.1] - 2017-07-04
### Changed
- Added empty lines after magic comments (per `rubocop`).
- Added empty lines after inline `RSpec` `subject` (per `rubocop`).
- Namespace of `MultilineMethodCallBraceLayout` and
  `MultilineMethodCallIndentation` (per `rubocop`).
- Disabled `Style/IndentHeredoc` in `spec/united_states_spec.rb`.

### Fixed
- `UnitedStates.names` would throw `NameError: uninitialized constant
   UnitedStates::Pathname` due to missing `require` statements.
