### PR TITLE
- All development dependencies now locked at `'~> 0'` per `RubyGems`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ __Change Groups__:
 
 ## [Unreleased]
 
+## [1.2.2] - 2017-07-04
+### Fixed
+- `UnitedStates.names` would throw `RuntimeError:
+  "./lib/united_states/designations.yml" does not exist.
+  Please supply a path to a YAML file.` due to assumed working directory.
+- `UnitedStates.names` would throw `NameError: uninitialized constant
+  UnitedStates::YAML` due to missing `require` statements.
+
 ## [1.2.1] - 2017-07-04
 ### Changed
 - Added empty lines after magic comments (per `rubocop`).

--- a/lib/united_states.rb
+++ b/lib/united_states.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'yaml'
 require 'united_states/version'
 require 'united_states/state/designation'
 
@@ -97,7 +98,7 @@ module UnitedStates
   # @return [String]
   #  the path to the Designations yaml file
   def self.config_path
-    './lib/united_states/designations.yml'
+    Pathname.new(__FILE__).parent.join('united_states/designations.yml')
   end
 
   # @example

--- a/lib/united_states/version.rb
+++ b/lib/united_states/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UnitedStates
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
 end

--- a/spec/united_states_spec.rb
+++ b/spec/united_states_spec.rb
@@ -546,8 +546,10 @@ Wisconsin:
   describe '.config_path' do
     subject(:config_path) { described_class.config_path }
 
-    it 'is "./lib/united_states/designations.yml"' do
-      is_expected.to eq('./lib/united_states/designations.yml')
+    it 'is "/.../lib/united_states/designations.yml"' do
+      is_expected.to eq(
+        Pathname.new(__FILE__).parent.parent.join(
+          'lib/united_states/designations.yml'))
     end
   end
 


### PR DESCRIPTION
## [1.2.2] - 2017-07-04
### Changed
- All development dependencies now locked at `'~> 0'` per `RubyGems`
  `open-ended dependency` warning.

### Fixed
- `UnitedStates.names` would throw `RuntimeError:
  "./lib/united_states/designations.yml" does not exist.
  Please supply a path to a YAML file.` due to assumed working directory.
- `UnitedStates.names` would throw `NameError: uninitialized constant
  UnitedStates::YAML` due to missing `require` statements.

closes #33